### PR TITLE
added X-Forwarded-Host header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-version='1.2.1'
+version='1.2.2'
 
 repositories {
     mavenCentral()

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -16,7 +16,7 @@ public class BurpExtender implements IBurpExtender {
         var menu = new ManualAttackMenu(callbacks, attacker);
         callbacks.registerContextMenuFactory(menu);
 
-        stdout.println("Host Header Inchecktion v1.2.1 loaded.");
+        stdout.println("Host Header Inchecktion v1.2.2 loaded.");
     }
 
 }

--- a/src/main/java/burp/HostHeaderInjection.java
+++ b/src/main/java/burp/HostHeaderInjection.java
@@ -31,6 +31,10 @@ enum HostHeaderInjection {
             HostHeaderInjection::generateXHostHostHeader,
             "Host: www.example.com<br/>X-Host: [PAYLOAD]"),
 
+    X_FORWARDED_HOST("X-Forwarded-Host Header",
+        HostHeaderInjection::generateXForwardedHostHostHeader,
+        "Host: www.example.com<br/>X-Forwarded-Host: [PAYLOAD]"),
+
     X_FORWARDED_SERVER("X-Forwarded-Server Header",
             HostHeaderInjection::generateXForwardedServerHostHeader,
             "Host: www.example.com<br/>X-Forwarded-Server: [PAYLOAD]"),
@@ -114,6 +118,10 @@ enum HostHeaderInjection {
 
     private static List<String> generateXHostHostHeader(String payload, List<String> headers) {
         return addHeaderAfterHostHeader(headers, "X-Host: " + payload);
+    }
+
+    private static List<String> generateXForwardedHostHostHeader(String payload, List<String> headers) {
+        return addHeaderAfterHostHeader(headers, "X-Forwarded-Host: " + payload);
     }
 
     private static List<String> generateXForwardedServerHostHeader(String payload, List<String> headers) {


### PR DESCRIPTION
added the X-Forwarded-Host header. 

> The X-Forwarded-Host (XFH) header is a de-facto standard header for identifying the original host requested by the client in the [Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) HTTP request header.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host